### PR TITLE
Add `makeLazy` and `makeWithLazy` function to build `ScopedCache` instances taking `R` as late as possible (not when building the cache, but when building the instance)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.watcherExclude": {
-    "**/target": true
-  }
-}

--- a/zio-cache/shared/src/test/scala/zio/cache/ScopedCacheSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/ScopedCacheSpec.scala
@@ -549,7 +549,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
                     (_: Exit[Nothing, Unit]) =>
                       10.second
                   }
-                  .flatMap { (scopedCache: ScopedCache[Unit, Nothing, Unit]) =>
+                  .flatMap { (scopedCache: ScopedCache[Unit, Any, Nothing, Unit]) =>
                     val subManaged = scopedCache.get(())
                     for {
                       _                               <- ZIO.scoped(subManaged.unit)
@@ -579,7 +579,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
                           .makeWith(10, ScopedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                             10.second
                           }
-                          .flatMap { (scopedCache: ScopedCache[Unit, Nothing, Unit]) =>
+                          .flatMap { (scopedCache: ScopedCache[Unit, Any, Nothing, Unit]) =>
                             val useGetManaged = ZIO.scoped(scopedCache.get(key = ()).unit)
                             for {
                               _             <- useGetManaged
@@ -610,7 +610,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
                           .makeWith(10, ScopedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                             10.second
                           }
-                          .flatMap { (scopedCache: ScopedCache[Unit, Nothing, Unit]) =>
+                          .flatMap { (scopedCache: ScopedCache[Unit, Any, Nothing, Unit]) =>
                             for {
                               scope                           <- Scope.make
                               acquire                          = scopedCache.get(()).provideEnvironment(ZEnvironment(scope))
@@ -639,7 +639,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
                           .makeWith(10, ScopedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                             10.second
                           }
-                          .flatMap { (scopedCache: ScopedCache[Unit, Nothing, Unit]) =>
+                          .flatMap { (scopedCache: ScopedCache[Unit, Any, Nothing, Unit]) =>
                             for {
                               _            <- ZIO.scoped(scopedCache.get(key = ()).unit)
                               _            <- fakeClock.advance(9.second)
@@ -672,7 +672,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
                           .makeWith(10, ScopedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                             10.second
                           }
-                          .flatMap { (scopedCache: ScopedCache[Unit, Nothing, Unit]) =>
+                          .flatMap { (scopedCache: ScopedCache[Unit, Any, Nothing, Unit]) =>
                             for {
                               _            <- ZIO.scoped(scopedCache.get(key = ()).unit)
                               _            <- fakeClock.advance(11.second)
@@ -703,7 +703,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
                           .makeWith(10, ScopedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                             10.second
                           }
-                          .flatMap { (scopedCache: ScopedCache[Unit, Nothing, Unit]) =>
+                          .flatMap { (scopedCache: ScopedCache[Unit, Any, Nothing, Unit]) =>
                             for {
                               scope                      <- Scope.make
                               acquire                     = scopedCache.get(key = ()).provideEnvironment(ZEnvironment(scope))
@@ -1019,7 +1019,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
     }
 
     def applyResourceOperations[V](
-      scopedCache: ScopedCache[Key, Throwable, V],
+      scopedCache: ScopedCache[Key, Any, Throwable, V],
       resourceOperations: List[ResourceOperation],
       ignoreCacheError: Boolean = false
     ): IO[TestFailure[Nothing], Map[ResourceId, Releaser]] =


### PR DESCRIPTION
**Proposal:**

This PR adds two new functions in the `ScopedCache` object (I will add them to the `Cache` object too is this proposal is accepted): `makeLazy` and `makeLazyWith` (we can probably find better names)
Unlike their eager counter parts, `make` and `makeWith`, these functions doesn't require the `Environment` part to build the cache:
```scala
def make[Key, Environment: Tag, Error, Value](...): ZIO[Environment with Scope, Nothing, ScopedCache[Key, Any, Error, Value]] =
```
They only require the `Environment` part when the user calls `.get`:
```scala
def makeLazy[Key, Environment: Tag, Error, Value](...): ZIO[Scope, Nothing, ScopedCache[Key, Environment, Error, Value]] =
```

**TODO:**
- [ ] Find better names for these functions?
- [ ] Implement them in `Cache` object
- [ ] Add doc
- [ ] Add tests